### PR TITLE
feat(subtensor): Add API for accessing hyperparameters V2

### DIFF
--- a/tests/test_bittensor/test_subnet.py
+++ b/tests/test_bittensor/test_subnet.py
@@ -99,6 +99,88 @@ async def test_get_hyperparameters(mocked_subtensor, bittensor):
 
 
 @pytest.mark.asyncio
+async def test_get_hyperparameters_v2(mocked_subtensor, bittensor):
+    mocked_subtensor.subnet_info.get_subnet_hyperparams_v2.return_value = {
+        "rho": 10,
+        "kappa": 32767,
+        "immunity_period": 4096,
+        "min_allowed_weights": 0,
+        "max_weights_limit": 65535,
+        "tempo": 100,
+        "min_difficulty": 10_000_000,
+        "max_difficulty": 4_611_686_018_427_387_903,
+        "weights_version": 0,
+        "weights_rate_limit": 100,
+        "adjustment_interval": 100,
+        "activity_cutoff": 5000,
+        "registration_allowed": True,
+        "target_regs_per_interval": 2,
+        "min_burn": 500_000,
+        "max_burn": 100_000_000_000,
+        "bonds_moving_avg": 900_000,
+        "max_regs_per_block": 1,
+        "serving_rate_limit": 50,
+        "max_validators": 64,
+        "adjustment_alpha": 0,
+        "difficulty": 10_000_000,
+        "commit_reveal_period": 1,
+        "commit_reveal_weights_enabled": False,
+        "alpha_high": 58_982,
+        "alpha_low": 45_875,
+        "liquid_alpha_enabled": False,
+        "alpha_sigmoid_steepness": {
+            "bits": 4_294_967_296_000,
+        },
+        "yuma_version": 1,
+        "subnet_is_active": True,
+        "transfers_enabled": True,
+        "bonds_reset_enabled": False,
+        "user_liquidity_enabled": False,
+    }
+
+    subnet_ref = bittensor.subnet(1)
+    subnet_hyperparameters = await subnet_ref.get_hyperparameters_v2()
+
+    assert subnet_hyperparameters == {
+        "rho": 10,
+        "kappa": 32767,
+        "immunity_period": 4096,
+        "min_allowed_weights": 0,
+        "max_weights_limit": 65535,
+        "tempo": 100,
+        "min_difficulty": 10_000_000,
+        "max_difficulty": 4_611_686_018_427_387_903,
+        "weights_version": 0,
+        "weights_rate_limit": 100,
+        "adjustment_interval": 100,
+        "activity_cutoff": 5000,
+        "registration_allowed": True,
+        "target_regs_per_interval": 2,
+        "min_burn": 500_000,
+        "max_burn": 100_000_000_000,
+        "bonds_moving_avg": 900_000,
+        "max_regs_per_block": 1,
+        "serving_rate_limit": 50,
+        "max_validators": 64,
+        "adjustment_alpha": 0,
+        "difficulty": 10_000_000,
+        "commit_reveal_period": 1,
+        "commit_reveal_weights_enabled": False,
+        "alpha_high": 58_982,
+        "alpha_low": 45_875,
+        "liquid_alpha_enabled": False,
+        "alpha_sigmoid_steepness": {
+            "bits": 4_294_967_296_000,
+        },
+        "yuma_version": 1,
+        "subnet_is_active": True,
+        "transfers_enabled": True,
+        "bonds_reset_enabled": False,
+        "user_liquidity_enabled": False,
+    }
+
+
+@pytest.mark.asyncio
 async def test_get_state(mocked_subtensor, bittensor):
     mocked_subtensor.subnet_info.get_subnet_state.return_value = {
         "active": [True],

--- a/tests/test_subtensor/test_runtime/test_subnet_info.py
+++ b/tests/test_subtensor/test_runtime/test_subnet_info.py
@@ -114,6 +114,72 @@ async def test_get_subnet_hyperparams_not_found(subtensor, mocked_transport):
 
 
 @pytest.mark.asyncio
+async def test_get_subnet_hyperparams_v2(subtensor, mocked_transport):
+    mocked_transport.responses["state_call"][
+        "SubnetInfoRuntimeApi_get_subnet_hyperparams_v2"
+    ] = {
+        "result": "0x0128feff0100014000feff03009101025a620213ffffffffffffff3f0091019101214e010482841e000700e876481782ee360004c8010100025a620204019a990300cecc02000000000000e80300000800010000",
+    }
+
+    subnet_hyperparams = await subtensor.subnet_info.get_subnet_hyperparams_v2(
+        netuid=1,
+    )
+
+    assert subnet_hyperparams == {
+        "rho": 10,
+        "kappa": 32767,
+        "immunity_period": 4096,
+        "min_allowed_weights": 0,
+        "max_weights_limit": 65535,
+        "tempo": 100,
+        "min_difficulty": 10_000_000,
+        "max_difficulty": 4_611_686_018_427_387_903,
+        "weights_version": 0,
+        "weights_rate_limit": 100,
+        "adjustment_interval": 100,
+        "activity_cutoff": 5000,
+        "registration_allowed": True,
+        "target_regs_per_interval": 1,
+        "min_burn": 500_000,
+        "max_burn": 100_000_000_000,
+        "bonds_moving_avg": 900_000,
+        "max_regs_per_block": 1,
+        "serving_rate_limit": 50,
+        "max_validators": 64,
+        "adjustment_alpha": 0,
+        "difficulty": 10_000_000,
+        "commit_reveal_period": 1,
+        "commit_reveal_weights_enabled": True,
+        "alpha_high": 58_982,
+        "alpha_low": 45_875,
+        "liquid_alpha_enabled": False,
+        "alpha_sigmoid_steepness": {
+            "bits": 4_294_967_296_000,
+        },
+        "yuma_version": 2,
+        "subnet_is_active": False,
+        "transfers_enabled": True,
+        "bonds_reset_enabled": False,
+        "user_liquidity_enabled": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_subnet_hyperparams_v2_not_found(subtensor, mocked_transport):
+    mocked_transport.responses["state_call"][
+        "SubnetInfoRuntimeApi_get_subnet_hyperparams_v2"
+    ] = {
+        "result": "0x00",
+    }
+
+    subnet_hyperparams = await subtensor.subnet_info.get_subnet_hyperparams_v2(
+        netuid=404,
+    )
+
+    assert subnet_hyperparams is None
+
+
+@pytest.mark.asyncio
 async def test_get_subnet_state(subtensor, mocked_transport):
     mocked_transport.responses["state_call"][
         "SubnetInfoRuntimeApi_get_subnet_state"

--- a/turbobt/subnet.py
+++ b/turbobt/subnet.py
@@ -10,6 +10,7 @@ import scalecodec.utils.ss58
 
 from turbobt.subtensor.runtime.subnet_info import (
     SubnetHyperparams,
+    SubnetHyperparamsV2,
     SubnetState,
 )
 from turbobt.subtensor.types import HotKey, Uid
@@ -405,6 +406,12 @@ class SubnetReference:
 
     async def get_hyperparameters(self, block_hash: str | None = None) -> SubnetHyperparams | None:
         return await self.client.subtensor.subnet_info.get_subnet_hyperparams(
+            self.netuid,
+            block_hash=block_hash or get_ctx_block_hash(),
+        )
+
+    async def get_hyperparameters_v2(self, block_hash: str | None = None) -> SubnetHyperparamsV2 | None:
+        return await self.client.subtensor.subnet_info.get_subnet_hyperparams_v2(
             self.netuid,
             block_hash=block_hash or get_ctx_block_hash(),
         )

--- a/turbobt/subtensor/runtime/subnet_info.py
+++ b/turbobt/subtensor/runtime/subnet_info.py
@@ -20,6 +20,11 @@ class SubnetHyperparams(typing.TypedDict):
     # ...
 
 
+class SubnetHyperparamsV2(typing.TypedDict):
+    max_weights_limit: int
+    # ...
+
+
 class SubnetState(typing.TypedDict):
     hotkeys: list[str]
     coldkeys: list[str]
@@ -82,6 +87,34 @@ class SubnetInfoRuntimeApi(RuntimeApi):
         hyperparameters = await self.subtensor.api_call(
             "SubnetInfoRuntimeApi",
             "get_subnet_hyperparams",
+            netuid=netuid,
+            block_hash=block_hash,
+        )
+
+        if not hyperparameters:
+            return None
+
+        return hyperparameters
+
+    async def get_subnet_hyperparams_v2(
+        self,
+        netuid: int,
+        block_hash=None,
+    ) -> SubnetHyperparamsV2 | None:
+        """
+        Fetches hyperparameters version 2 of a subnet.
+
+        :param netuid: The unique identifier of the subnet.
+        :type netuid: int
+        :param block_hash: Optional block hash to query the subnet state at a specific block.
+        :type block_hash: str, optional
+        :return: A dictionary containing hyperparameters of the subnet, or None if no subnet is found.
+        :rtype: SubnetHyperparamsV2 | None
+        """
+
+        hyperparameters = await self.subtensor.api_call(
+            "SubnetInfoRuntimeApi",
+            "get_subnet_hyperparams_v2",
             netuid=netuid,
             block_hash=block_hash,
         )


### PR DESCRIPTION
This change adds the following APIS:
* SubnetReference::get_hyperparameters_v2
* SubnetInfoRuntimeApi::get_subnet_hyperparams_v2
alongside the existing ones for v1 hyperparameters.
A new type SubnetHyperparamsV2 is introduced.

The I32U32 type (used for alpha_sigmoid_steepness) is deserialized into raw bits,
instead of a proper Python fixed-point decimal.

issue: BTSDK-18
